### PR TITLE
MIT license, remove readme

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -1,8 +1,0 @@
-Sample Server construct here.
-
-How to install node.js:
-	https://howtonode.org/how-to-install-nodejs
-
-Start server with "node server.js"
-
-Save html,css and other files in public folder

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "node lib/main",
     "test": "node tests/main && standard"
   },
-  "license": "MIT",
+  "license": "Apache-2.0",
   "devDependencies": {
     "chai": "^3.5.0",
     "chai-as-promised": "^5.3.0",


### PR DESCRIPTION
- Remove the readme in `lib/`. The instructions are in our main readme
- ~~Use MIT license. Either that or set `package.json`'s license field to Apache license. Which license doesn't matter to me. MIT license is shorter and I'd say is used in most open source JS projects. That makes it kind of the default choice.~~ Edit: I changed the license field because I see that the license was commited by a supervisor. Let's leave it as is.
