### PR TITLE
Request proxy for /api route

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,6 +1,6 @@
 module.exports = {
-    listenAddress: process.env.LISTEN_ADDRESS || '127.0.0.1',
-    listenPort: process.env.LISTEN_PORT || '8080',
-    apiHost: process.env.API_HOST || '127.0.0.1',
-    apiPort: process.env.API_PORT || '8000'
-};
+  listenAddress: process.env.LISTEN_ADDRESS || '127.0.0.1',
+  listenPort: process.env.LISTEN_PORT || '8080',
+  apiHost: process.env.API_HOST || '127.0.0.1',
+  apiPort: process.env.API_PORT || '8000'
+}

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,4 +1,6 @@
 module.exports = {
     listenAddress: process.env.LISTEN_ADDRESS || '127.0.0.1',
-    listenPort: process.env.LISTEN_PORT || '8080'
+    listenPort: process.env.LISTEN_PORT || '8080',
+    apiHost: process.env.API_HOST || '127.0.0.1',
+    apiPort: process.env.API_PORT || '8000'
 };

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,6 +1,6 @@
 module.exports = {
   listenAddress: process.env.LISTEN_ADDRESS || '127.0.0.1',
   listenPort: process.env.LISTEN_PORT || '8080',
-  apiHost: process.env.API_HOST || '127.0.0.1',
-  apiPort: process.env.API_PORT || '8000'
+  apiHost: process.env.API_HOST || 'pokedata.c4e3f8c7.svc.dockerapp.io',
+  apiPort: process.env.API_PORT || '65014'
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,5 +1,5 @@
 const PokemonSite = require('./pokemon-site')
-const config = require('./config');
+const config = require('./config')
 
 const pokemonSite = new PokemonSite(config)
 

--- a/lib/pokemon-site.js
+++ b/lib/pokemon-site.js
@@ -2,8 +2,8 @@ const express = require('express')
 const bodyParser = require('body-parser')
 const path = require('path')
 const http = require('http')
-const proxy = require('express-http-proxy');
-const url = require('url');
+const proxy = require('express-http-proxy')
+const url = require('url')
 
 class PokemonSite {
   constructor (config) {
@@ -16,10 +16,10 @@ class PokemonSite {
     app.use(express.static(path.join(__dirname, 'public')))
 
     // Proxy requests to /api/* to API backend
-    var apiEndpoint = config.apiHost + ':' + config.apiPort;
+    var apiEndpoint = config.apiHost + ':' + config.apiPort
     app.use('/api/*', proxy(apiEndpoint, {
       forwardPath: (req, res) => url.parse(req.baseUrl).path
-    }));
+    }))
 
     this._app = app
 

--- a/lib/pokemon-site.js
+++ b/lib/pokemon-site.js
@@ -2,6 +2,8 @@ const express = require('express')
 const bodyParser = require('body-parser')
 const path = require('path')
 const http = require('http')
+const proxy = require('express-http-proxy');
+const url = require('url');
 
 class PokemonSite {
   constructor (config) {
@@ -9,7 +11,16 @@ class PokemonSite {
     const app = express()
     app.use(bodyParser.json())
     app.get('/', (req, res) => { res.redirect('index.html') })
-    app.use(express.static(path.join(__dirname, 'public'))) // Serve `/public`
+
+    // Serve static content from /public directory
+    app.use(express.static(path.join(__dirname, 'public')))
+
+    // Proxy requests to /api/* to API backend
+    var apiEndpoint = config.apiHost + ':' + config.apiPort;
+    app.use('/api/*', proxy(apiEndpoint, {
+      forwardPath: (req, res) => url.parse(req.baseUrl).path
+    }));
+
     this._app = app
 
     // Start listening

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "body-parser": "^1.15.2",
-    "express": "^4.14.0"
+    "express": "^4.14.0",
+    "express-http-proxy": "^0.10.0"
   }
 }


### PR DESCRIPTION
I added a http request proxy to our node backend that redirects requests to `/api`to the backend of the PokeData team. The address and port of the backend host can be configured via environment variables. 

Why is this needed? Most importantly, to work around the [Same Origin Policy](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy). Additionally, this gives us a single clean server endpoint and makes it easier to connect different docker containers. 
