### PR TITLE
Fix shut down behavior of server

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -9,6 +9,9 @@ const signals = [
   'SIGBUS', 'SIGFPE', 'SIGUSR1', 'SIGSEGV', 'SIGUSR2', 'SIGTERM'
 ]
 function closeApp () {
-  return pokemonSite.close().then(() => { process.exit(1) })
+  return pokemonSite.close().then(() => {
+    console.log('Stopped app')
+    process.exit(1)
+  })
 }
 for (let signal of signals) { process.on(signal, closeApp) }

--- a/lib/pokemon-site.js
+++ b/lib/pokemon-site.js
@@ -24,11 +24,21 @@ class PokemonSite {
     this._app = app
 
     // Start listening
-    const server = http.createServer(app)
-    server.listen(config.listenPort, config.listenAddress, () => {
+    this._server = http.createServer(app)
+    this._server.listen(config.listenPort, config.listenAddress, () => {
       console.log('Listening on %s:%d ...', config.listenAddress, config.listenPort)
     })
-    this._server = server
+
+    // Keep track of open connections
+    this.socketId = 0
+    this.sockets = {}
+    this._server.on('connection', (socket) => {
+      let socketId = ++this.socketId
+      this.sockets[socketId] = socket
+
+      // Remove connection after it has been closed
+      socket.on('close', () => delete this.sockets[socketId])
+    })
   }
 
   /**
@@ -37,13 +47,16 @@ class PokemonSite {
   @return {Promise}
   */
   close () {
+    console.log('Shutting down server...')
+
     return new Promise((resolve, reject) => {
+      // Close all open connections
+      Object.keys(this.sockets).forEach(socketId => this.sockets[socketId].destroy())
+
       this._server.close((err) => {
         if (err) { reject(err) } else { resolve() }
       })
-    }).then(() => {
-      console.log('Stopped app')
-    })
+    }).then(() => console.log('Server terminated'))
   }
 }
 

--- a/lib/pokemon-site.js
+++ b/lib/pokemon-site.js
@@ -33,7 +33,7 @@ class PokemonSite {
     this.socketId = 0
     this.sockets = {}
     this._server.on('connection', (socket) => {
-      let socketId = ++this.socketId
+      let socketId = this.socketId++
       this.sockets[socketId] = socket
 
       // Remove connection after it has been closed


### PR DESCRIPTION
When calling `server.close()` the server won't actually shut down until all connections are terminated (which can take quite a while because of keep-alive). So let's keep track of open connections and close them before shutting down the server.
Fixes #34.
