### PR TITLE
Fix: Docker container does not receive STOP signal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ WORKDIR server
 ENV LISTEN_ADDRESS=0.0.0.0
 ENV LISTEN_PORT=8080
 EXPOSE 8080
-CMD npm start
+CMD ["npm", "start"]


### PR DESCRIPTION
When using `docker stop` to terminate the server process the container would not receive the stop signal and continue to run.
