### PR TITLE
Fix: gulp returns exit code 0 on error

### DIFF
--- a/ionic2/gulpfile.js
+++ b/ionic2/gulpfile.js
@@ -32,10 +32,15 @@ function applyOptions(options, fn) {
   return (callOptions) => fn(Object.assign(callOptions, options));
 }
 
+function handleError(error) {
+  console.error(error.toString());
+  process.exit(1);
+}
+
 var outputDir = '../server/app';
 
 // Change output destination to server directory
-var buildBrowserify = applyOptions({outputPath: outputDir + '/js'}, require('ionic-gulp-browserify-typescript'));
+var buildBrowserify = applyOptions({outputPath: outputDir + '/js', onError: handleError}, require('ionic-gulp-browserify-typescript'));
 var buildSass = applyOptions({dest: outputDir + '/css'}, require('ionic-gulp-sass-build'));
 var copyHTML = applyOptions({dest: outputDir}, require('ionic-gulp-html-copy'));
 var copyFonts = applyOptions({dest: outputDir + '/fonts'}, require('ionic-gulp-fonts-copy'));
@@ -58,7 +63,11 @@ gulp.task('watch', ['clean'], function(done){
 gulp.task('build', ['clean'], function(done){
   runSequence(
     ['sass', 'html', 'fonts', 'scripts'],
-    function(){
+    function(error){
+      if (error) {
+        handleError(error);
+      }
+
       buildBrowserify({
         minify: isRelease,
         browserifyOptions: {


### PR DESCRIPTION
When `gulp build` fails it will still return exit code `0` nonetheless. This makes Travis believe the build was successful.

```
[22:28:51] $ node_modules/gulp/bin/gulp.js build --release
[22:28:51] Using gulpfile ~/build/PokemonGoers/Catch-em-all/ionic2/gulpfile.js
[22:28:51] Starting 'clean'...
[22:28:51] Finished 'clean' after 6.51 ms
[22:28:51] Starting 'build'...
[22:28:51] Starting 'sass'...
[22:28:51] Starting 'html'...
[22:28:51] Starting 'fonts'...
[22:28:51] Starting 'scripts'...
[22:28:51] Finished 'html' after 59 ms
[22:28:51] Finished 'scripts' after 57 ms
[22:28:51] Finished 'fonts' after 64 ms
[22:28:52] Finished 'sass' after 1.04 s
Error: Cannot find module '../../../../../PokeMap-2/index.js' from '/home/travis/build/PokemonGoers/Catch-em-all/ionic2/app/pages/map'
[22:28:54] Finished 'build' after 3.73 s
Error: Cannot find module './js/opencyclemap' from '/home/travis/build/PokemonGoers/Catch-em-all/ionic2/node_modules/pokemap-2'
```

https://travis-ci.org/PokemonGoers/Catch-em-all/builds/158307702
