### PR TITLE
Recover from gulp build failure when in development environment

### DIFF
--- a/ionic2/gulpfile.js
+++ b/ionic2/gulpfile.js
@@ -34,7 +34,11 @@ function applyOptions(options, fn) {
 
 function handleError(error) {
   console.error(error.toString());
-  process.exit(1);
+  if (isRelease) {
+    // During development we don't want to stop the process because
+    // ionic will automatically recover and restart the gulp build.
+    process.exit(1);
+  }
 }
 
 var outputDir = '../server/app';


### PR DESCRIPTION
With #39 I overshoot a bit. Now when running `ionic serve` a syntax error will ultimately stop the ionic process and one has to restart it manually. 
This tiny change should fix this inconvenience.
