### PR TITLE
Pass build environment to app to enable different api endpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,10 @@ RUN cd ionic2 && ionic build browser
 # Clean workspace
 RUN rm -rf ionic2
 
-WORKDIR server
 ENV LISTEN_ADDRESS=0.0.0.0
 ENV LISTEN_PORT=8080
+ENV API_ENDPOINT=http://pokedata.c4e3f8c7.svc.dockerapp.io:65014
+
+WORKDIR server
 EXPOSE 8080
 CMD ["npm", "start"]

--- a/ionic2/app/app.ts
+++ b/ionic2/app/app.ts
@@ -5,16 +5,19 @@ import 'rxjs/add/operator/map';
 
 import { MapPage } from "./pages/map/map.page";
 import { NavSidebarComponent } from './components/nav-sidebar/nav-sidebar.component';
+import globals from './globals';
 
 // Provider
 import { ApiService } from './services/api.service';
 import { LocationService } from './services/location.service';
+import { ConfigService } from './services/config.service';
 
-declare const BUILD_ENV: string;
-declare const BUILD_TIME: string;
+console.log('BUILD_ENV', globals.BUILD_ENV);
+console.log('BUILD_TIME', globals.BUILD_TIME);
+console.log('BUILD_TARGET', globals.BUILD_TARGET);
+console.log('API_ENDPOINT', globals.API_ENDPOINT);
 
-if (BUILD_ENV === 'release') {
-  console.log('Build time:', BUILD_TIME);
+if (globals.BUILD_ENV === 'release') {
   enableProdMode();
 }
 
@@ -23,7 +26,8 @@ if (BUILD_ENV === 'release') {
   directives: [NavSidebarComponent],
   providers: [
     ApiService,
-    LocationService
+    LocationService,
+    ConfigService
   ]
 })
 export class App {

--- a/ionic2/app/globals.ts
+++ b/ionic2/app/globals.ts
@@ -1,0 +1,12 @@
+// Exports global constants from webpack build
+declare const BUILD_ENV: string;
+declare const BUILD_TIME: string;
+declare const BUILD_TARGET: string;
+declare const API_ENDPOINT: string;
+
+export default {
+  BUILD_ENV: BUILD_ENV,
+  BUILD_TIME: BUILD_TIME,
+  BUILD_TARGET: BUILD_TARGET,
+  API_ENDPOINT: API_ENDPOINT
+};

--- a/ionic2/app/models/pokemon.ts
+++ b/ionic2/app/models/pokemon.ts
@@ -1,3 +1,9 @@
+import { ReflectiveInjector } from '@angular/core';
+import { ConfigService } from '../services/config.service';
+
+const configServiceInjector = ReflectiveInjector.resolveAndCreate([ConfigService]);
+const config: ConfigService = configServiceInjector.get(ConfigService);
+
 export type PokemonGender = 'm' | 'f' | 'g' | 'h';
 export type PokemonAttackCategory = 'fast' | 'special';
 
@@ -61,7 +67,7 @@ export class Pokemon {
     return Object.assign(instance, object);
   }
 
-  get icon():string {
-    return '/api/pokemon/id/' + this.pokemonId + '/icon';
+  get icon(): string {
+    return config.apiEndpoint + '/api/pokemon/id/' + this.pokemonId + '/icon';
   }
 }

--- a/ionic2/app/pages/map/map.page.spec.ts
+++ b/ionic2/app/pages/map/map.page.spec.ts
@@ -2,6 +2,7 @@ import { addProviders, beforeEach, it, describe, expect, inject } from '@angular
 import { MapPage } from './map.page';
 import { Events } from 'ionic-angular';
 import { App, PopoverController, Platform, Config, NavParams } from 'ionic-angular';
+import { ConfigService } from '../../services/config.service';
 
 describe('Map', () => {
     let config: Config
@@ -9,17 +10,19 @@ describe('Map', () => {
     let app: App
     let popoverCtrl: PopoverController
     let events: Events
+    let configService: ConfigService
     let navParams: NavParams
     let mapPage: MapPage
 
-    beforeEach(() => { 
+    beforeEach(() => {
         config = new Config()
         platform = new Platform()
         app = new App(config, platform);
         popoverCtrl = new PopoverController(app)
         events = new Events()
+        configService = new ConfigService()
         navParams = new NavParams()
-        mapPage = new MapPage(popoverCtrl, events, navParams)
+        mapPage = new MapPage(popoverCtrl, events, configService, navParams)
         mapPage.ngOnInit()
         addProviders([])
     });

--- a/ionic2/app/pages/map/map.page.ts
+++ b/ionic2/app/pages/map/map.page.ts
@@ -5,6 +5,7 @@ import { Geolocation } from 'ionic-native';
 import { FilterPopoverComponent } from '../../components/filter-popover/filter-popover.component';
 import { MapComponent } from '../../components/map/map.component';
 import { NavbarComponent } from '../../components/navbar/navbar.component';
+import { ConfigService } from '../../services/config.service';
 
 @Page({
   template: require('./map.page.html'),
@@ -28,7 +29,8 @@ export class MapPage implements OnInit {
     }
   };
 
-  constructor(private popoverCtrl: PopoverController, private events: Events, navParams: NavParams) {
+  constructor(private popoverCtrl: PopoverController, private events: Events,
+              private config: ConfigService, navParams: NavParams) {
     if (navParams.get('latitude') && navParams.get('longitude')) {
       this.latitude = navParams.get('latitude');
       this.longitude = navParams.get('longitude');
@@ -66,7 +68,7 @@ export class MapPage implements OnInit {
 
   initializeMap(coordinates) {
     let timeRange = {from: this.filter.time.lower, to: this.filter.time.upper};
-    let apiEndpoint = window.location.origin;
+    let apiEndpoint = this.config.apiEndpoint;
     this.map.initialize({coordinates, timeRange, apiEndpoint});
   }
 

--- a/ionic2/app/services/api.service.ts
+++ b/ionic2/app/services/api.service.ts
@@ -8,13 +8,17 @@ import { Sighting } from '../models/sighting';
 import { PokemonGender } from "../models/pokemon";
 import { PokemonAttackCategory } from "../models/pokemon";
 import { SightingSource } from "../models/sighting";
+import { ConfigService } from './config.service';
 
-export { Pokemon, PokemonIcon, Sighting}
+export { Pokemon, PokemonIcon, Sighting }
 
 @Injectable()
 export class ApiService {
 
-  constructor(private http: Http) {
+  apiEndpoint: string;
+
+  constructor(private http: Http, config: ConfigService) {
+    this.apiEndpoint = config.apiEndpoint;
   }
 
   private static handleResponse(Type: any, expectSingle: boolean = false) {
@@ -49,7 +53,7 @@ export class ApiService {
    * @returns {Observable<Pokemon[]>}
    */
   getAllPokemon(): Observable<Pokemon[]> {
-    let request = this.http.get('/api/pokemon');
+    let request = this.http.get(this.apiEndpoint + '/api/pokemon');
     return request.map(ApiService.handleResponse(Pokemon));
   }
 
@@ -59,7 +63,7 @@ export class ApiService {
    * @returns {Observable<Pokemon>}
    */
   getPokemonById(id: number): Observable<Pokemon> {
-    let request = this.http.get('/api/pokemon/id/' + id);
+    let request = this.http.get(this.apiEndpoint + '/api/pokemon/id/' + id);
     return request.map(ApiService.handleResponse(Pokemon, true));
   }
 
@@ -69,7 +73,7 @@ export class ApiService {
    * @returns {Observable<Pokemon[]>}
    */
   getPokemonByName(name: string): Observable<Pokemon[]> {
-    let request = this.http.get('/api/pokemon/name/' + name);
+    let request = this.http.get(this.apiEndpoint + '/api/pokemon/name/' + name);
     return request.map(ApiService.handleResponse(Pokemon));
   }
 
@@ -79,7 +83,7 @@ export class ApiService {
    * @returns {Observable<Pokemon[]>}
    */
   getPokemonByGender(gender: PokemonGender): Observable<Pokemon[]> {
-    let request = this.http.get('/api/pokemon/gender/' + gender);
+    let request = this.http.get(this.apiEndpoint + '/api/pokemon/gender/' + gender);
     return request.map(ApiService.handleResponse(Pokemon));
   }
 
@@ -89,7 +93,7 @@ export class ApiService {
    * @returns {Observable<Pokemon[]>}
    */
   getPokemonByType(type: string): Observable<Pokemon[]> {
-    let request = this.http.get('/api/pokemon/type/' + type);
+    let request = this.http.get(this.apiEndpoint + '/api/pokemon/type/' + type);
     return request.map(ApiService.handleResponse(Pokemon));
   }
 
@@ -99,7 +103,7 @@ export class ApiService {
    * @returns {Observable<Pokemon[]>}
    */
   getPokemonByWeakness(weakness: string): Observable<Pokemon[]> {
-    let request = this.http.get('/api/pokemon/weakness/' + weakness);
+    let request = this.http.get(this.apiEndpoint + '/api/pokemon/weakness/' + weakness);
     return request.map(ApiService.handleResponse(Pokemon));
   }
 
@@ -109,7 +113,7 @@ export class ApiService {
    * @returns {Observable<Pokemon[]>}
    */
   getPokemonByResistance(resistance: string): Observable<Pokemon[]> {
-    let request = this.http.get('/api/pokemon/resistance/' + resistance);
+    let request = this.http.get(this.apiEndpoint + '/api/pokemon/resistance/' + resistance);
     return request.map(ApiService.handleResponse(Pokemon));
   }
 
@@ -120,7 +124,7 @@ export class ApiService {
    * @returns {Observable<Pokemon[]>}
    */
   getPokemonByAttackType(category: PokemonAttackCategory, type: string): Observable<Pokemon[]> {
-    let request = this.http.get('/api/pokemon/attack/' + category + '/type/' + type);
+    let request = this.http.get(this.apiEndpoint + '/api/pokemon/attack/' + category + '/type/' + type);
     return request.map(ApiService.handleResponse(Pokemon));
   }
 
@@ -131,7 +135,7 @@ export class ApiService {
    * @returns {Observable<Pokemon[]>}
    */
   getPokemonByAttackName(category: PokemonAttackCategory, name: string): Observable<Pokemon[]> {
-    let request = this.http.get('/api/pokemon/attack/' + category + '/name/' + name);
+    let request = this.http.get(this.apiEndpoint + '/api/pokemon/attack/' + category + '/name/' + name);
     return request.map(ApiService.handleResponse(Pokemon));
   }
 
@@ -142,7 +146,7 @@ export class ApiService {
    * @returns {Observable<Pokemon[]>}
    */
   getPokemonByAttackDamage(category: PokemonAttackCategory, damage: number): Observable<Pokemon[]> {
-    let request = this.http.get('/api/pokemon/attack/' + category + '/damage/' + damage);
+    let request = this.http.get(this.apiEndpoint + '/api/pokemon/attack/' + category + '/damage/' + damage);
     return request.map(ApiService.handleResponse(Pokemon));
   }
 
@@ -153,7 +157,7 @@ export class ApiService {
    * @returns {Observable<Pokemon[]>}
    */
   getPokemonByEvolutionId(category: PokemonAttackCategory, id: number): Observable<Pokemon[]> {
-    let request = this.http.get('/api/pokemon/evolution/' + category + '/id/' + id);
+    let request = this.http.get(this.apiEndpoint + '/api/pokemon/evolution/' + category + '/id/' + id);
     return request.map(ApiService.handleResponse(Pokemon));
   }
 
@@ -164,7 +168,7 @@ export class ApiService {
    * @returns {Observable<Pokemon[]>}
    */
   getPokemonByEvolutionName(category: PokemonAttackCategory, name: string): Observable<Pokemon[]> {
-    let request = this.http.get('/api/pokemon/evolution/' + category + '/name/' + name);
+    let request = this.http.get(this.apiEndpoint + '/api/pokemon/evolution/' + category + '/name/' + name);
     return request.map(ApiService.handleResponse(Pokemon));
   }
 
@@ -175,7 +179,7 @@ export class ApiService {
    */
   searchPokemon(query: Object): Observable<Pokemon[]> {
     let params = ApiService.createSearchParamsFromObject(query);
-    let request = this.http.get('/api/pokemon/search', {
+    let request = this.http.get(this.apiEndpoint + '/api/pokemon/search', {
       search: params
     });
     return request.map(ApiService.handleResponse(Pokemon));
@@ -187,7 +191,7 @@ export class ApiService {
    * @returns {Observable<PokemonIcon>}
    */
   getIconById(id: number): Observable<PokemonIcon> {
-    let request = this.http.get('/api/pokemon/id/' + id + '/icon');
+    let request = this.http.get(this.apiEndpoint + '/api/pokemon/id/' + id + '/icon');
     return request.map(ApiService.handleResponse(PokemonIcon, true));
   }
 
@@ -196,7 +200,7 @@ export class ApiService {
    * @returns {Observable<Sighting[]>}
    */
   getAllSightings(): Observable<Sighting[]> {
-    let request = this.http.get('/api/pokemon/sighting');
+    let request = this.http.get(this.apiEndpoint + '/api/pokemon/sighting');
     return request.map(ApiService.handleResponse(Sighting));
   }
 
@@ -206,7 +210,7 @@ export class ApiService {
    * @returns {Observable<Sighting>}
    */
   getSightingById(id: number): Observable<Sighting> {
-    let request = this.http.get('/api/pokemon/sighting/id/' + id);
+    let request = this.http.get(this.apiEndpoint + '/api/pokemon/sighting/id/' + id);
     return request.map(ApiService.handleResponse(Sighting, true));
   }
 
@@ -217,7 +221,7 @@ export class ApiService {
    * @returns {Observable<Sighting[]>}
    */
   getSightingBySource(source: SightingSource): Observable<Sighting[]> {
-    let request = this.http.get('/api/pokemon/sighting/source/' + source);
+    let request = this.http.get(this.apiEndpoint + '/api/pokemon/sighting/source/' + source);
     return request.map(ApiService.handleResponse(Sighting));
   }
 
@@ -228,7 +232,7 @@ export class ApiService {
    */
   getSightingAtCoordinates(coordinates: {longitude:number, latitude:number}): Observable<Sighting[]> {
     let coords = coordinates.longitude + ',' + coordinates.latitude;
-    let request = this.http.get('/api/pokemon/sighting/coordinates/' + coords);
+    let request = this.http.get(this.apiEndpoint + '/api/pokemon/sighting/coordinates/' + coords);
     return request.map(ApiService.handleResponse(Sighting));
   }
 
@@ -242,7 +246,7 @@ export class ApiService {
                                 to: {longitude:number, latitude:number}): Observable<Sighting[]> {
     let fromCoords = from.longitude + ',' + from.latitude;
     let toCoords = to.longitude + ',' + to.latitude;
-    let request = this.http.get('/api/pokemon/sighting/coordinates/from/' + fromCoords + '/to/' + toCoords);
+    let request = this.http.get(this.apiEndpoint + '/api/pokemon/sighting/coordinates/from/' + fromCoords + '/to/' + toCoords);
     return request.map(ApiService.handleResponse(Sighting));
   }
 
@@ -254,7 +258,7 @@ export class ApiService {
    * @returns {Observable<Sighting[]>}
    */
   getSightingByTimeRange(timestamp: string, range: string): Observable<Sighting[]> {
-    let request = this.http.get('/api/pokemon/sighting/ts/' + timestamp + '/range/' + range);
+    let request = this.http.get(this.apiEndpoint + '/api/pokemon/sighting/ts/' + timestamp + '/range/' + range);
     return request.map(ApiService.handleResponse(Sighting));
   }
 
@@ -265,7 +269,7 @@ export class ApiService {
    */
   searchSightings(query: Object): Observable<Sighting[]> {
     let params = ApiService.createSearchParamsFromObject(query);
-    let request = this.http.get('/api/pokemon/sighting/search', {
+    let request = this.http.get(this.apiEndpoint + '/api/pokemon/sighting/search', {
       search: params
     });
     return request.map(ApiService.handleResponse(Sighting));

--- a/ionic2/app/services/config.service.ts
+++ b/ionic2/app/services/config.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+
+declare const API_ENDPOINT: string;
+declare const BUILD_TARGET: string;
+
+@Injectable()
+export class ConfigService {
+
+  get apiEndpoint(): string {
+    if (BUILD_TARGET === 'web') {
+      // For build target 'web' we are running a node server alongside
+      // the app which proxies all api requests.
+      return window.location.origin;
+    } else if (API_ENDPOINT) {
+      return API_ENDPOINT;
+    } else {
+      return window.location.origin;
+    }
+  }
+
+}

--- a/ionic2/gulpfile.js
+++ b/ionic2/gulpfile.js
@@ -8,13 +8,11 @@ var argv = process.argv;
 var serverDir = path.join(__dirname, '../server/app');
 var outputDir = path.join(__dirname, 'www');
 
-var release = argv.includes('--release') || argv.includes('build');
 var shouldWatch = argv.includes('-l') || argv.includes('--livereload');
-
-process.env['BUILD_ENV'] = release ? 'release' : 'develop';
-gutil.log('Build environment: ' + process.env['BUILD_ENV']);
-
-var webpackConf = require('./webpack.config.js');
+var releaseBuild = argv.includes('--release') || argv.includes('build');
+var browserBuild = argv.includes('browser');
+var androidBuild = argv.includes('android');
+var iosBuild = argv.includes('ios');
 
 gulp.task('serve:before', ['watch']);
 gulp.task('emulate:before', ['build']);
@@ -22,14 +20,15 @@ gulp.task('deploy:before', ['build']);
 gulp.task('build:before', ['build']);
 gulp.task('run:before', [shouldWatch ? 'watch' : 'build']);
 
-var browserBuild = argv.includes('browser');
 if (browserBuild) {
   gulp.task('build:after', ['server-deploy']);
 }
 
-gulp.task('build', ['clean', 'assets', 'webpack']);
+gulp.task('build', ['environment', 'clean', 'assets', 'webpack']);
 
-gulp.task('watch', ['clean', 'assets'], function(done) {
+gulp.task('watch', ['environment', 'clean', 'assets'], function(done) {
+  var webpackConf = require('./webpack.config.js');
+
   gulp.watch('app/assets/**/*', gulp.start.bind(gulp, 'assets'));
   webpack({
     config: webpackConf,
@@ -37,20 +36,36 @@ gulp.task('watch', ['clean', 'assets'], function(done) {
   }).then(done);
 });
 
+// Runs webpack to Transpiles, bundles and optimizes the sources.
 gulp.task('webpack', function(done) {
+  var webpackConf = require('./webpack.config.js');
+
   webpack({
     config: webpackConf
   }).then(done);
 });
 
+// Sets environment variables.
+gulp.task('environment', function() {
+  process.env['BUILD_ENV'] = releaseBuild ? 'release' : 'develop';
+  process.env['BUILD_TARGET'] = browserBuild ? 'web' : androidBuild ? 'android' :
+    iosBuild ? 'ios' : process.env['BUILD_TARGET'];
+
+  gutil.log('BUILD_ENV=' + process.env['BUILD_ENV']);
+  gutil.log('BUILD_TARGET=' + process.env['BUILD_TARGET']);
+});
+
+// Cleans the output directory
 gulp.task('clean', function() {
   del.sync([outputDir + '/**/*']);
 });
 
+// Copies static assets (images, css, ...) to the output directory.
 gulp.task('assets', function() {
   gulp.src('app/assets/**/*').pipe(gulp.dest(outputDir));
 });
 
+// Copies the final sources to the node server directory.
 gulp.task('server-deploy', function() {
   del.sync([serverDir], {force: true});
   gulp.src('platforms/browser/www/**/*').pipe(gulp.dest(serverDir));

--- a/ionic2/webpack.config.js
+++ b/ionic2/webpack.config.js
@@ -3,10 +3,20 @@ var HtmlWebpackPlugin = require('html-webpack-plugin');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var path = require('path');
 
-var BUILD_ENV = process.env['BUILD_ENV'] || 'develop';
-var devEnv = BUILD_ENV === 'develop';
-
 var outputDir = path.join(__dirname, 'www');
+
+var BUILD_ENV = process.env['BUILD_ENV'] || 'develop';
+var BUILD_TARGET = process.env['BUILD_TARGET'] || 'web';
+var API_ENDPOINT = process.env['API_ENDPOINT'] || 'http://pokedata.c4e3f8c7.svc.dockerapp.io:65014';
+
+let buildConfig = {
+  BUILD_ENV: JSON.stringify(BUILD_ENV),
+  BUILD_TIME: JSON.stringify(new Date()),
+  BUILD_TARGET: JSON.stringify(BUILD_TARGET),
+  API_ENDPOINT: JSON.stringify(API_ENDPOINT)
+};
+
+var devEnv = BUILD_ENV === 'develop';
 
 module.exports = {
   colors: true,
@@ -66,10 +76,7 @@ module.exports = {
     ]
   },
   plugins: [
-    new webpack.DefinePlugin({
-      BUILD_ENV: JSON.stringify(BUILD_ENV),
-      BUILD_TIME: JSON.stringify(new Date())
-    }),
+    new webpack.DefinePlugin(buildConfig),
     new HtmlWebpackPlugin({
       template: './app/index.html',
       excludeChunks: ['style_ios', 'style_wp', 'style_md']

--- a/server/lib/config.js
+++ b/server/lib/config.js
@@ -1,6 +1,5 @@
 module.exports = {
   listenAddress: process.env.LISTEN_ADDRESS || '127.0.0.1',
   listenPort: process.env.LISTEN_PORT || '8080',
-  apiHost: process.env.API_HOST || 'pokedata.c4e3f8c7.svc.dockerapp.io',
-  apiPort: process.env.API_PORT || '65014'
+  apiEndpoint: process.env.API_ENDPOINT || 'pokedata.c4e3f8c7.svc.dockerapp.io:65014'
 }

--- a/server/lib/pokemon-site.js
+++ b/server/lib/pokemon-site.js
@@ -16,8 +16,7 @@ class PokemonSite {
     app.use(express.static(path.join(__dirname, '../app')))
 
     // Proxy requests to /api/* to API backend
-    var apiEndpoint = config.apiHost + ':' + config.apiPort
-    app.use('/api/*', proxy(apiEndpoint, {
+    app.use('/api/*', proxy(config.apiEndpoint, {
       forwardPath: (req, res) => url.parse(req.baseUrl).path
     }))
 


### PR DESCRIPTION
When running the app alongside a nodeJS server all requests to `http://localhost/api` are proxied to the actual API endpoint at `pokedata.c4e3f8c7.svc.dockerapp.io:65014`. However, when building the app for Android (or iOS) there won't be a node server which means requests need to be sent to `pokedata.c4e3f8c7.svc.dockerapp.io:65014` directly. 
For this I added a build environment parameter `API_ENDPOINT` to webpack which are passed to the ionic app. We can probably use this for other things as well.
