### PR TITLE
Cache and gzip server assets

### DIFF
--- a/server/lib/pokemon-site.js
+++ b/server/lib/pokemon-site.js
@@ -3,6 +3,7 @@ const bodyParser = require('body-parser')
 const path = require('path')
 const http = require('http')
 const proxy = require('express-http-proxy')
+const compression = require('compression')
 const url = require('url')
 
 class PokemonSite {
@@ -12,8 +13,11 @@ class PokemonSite {
     app.use(bodyParser.json())
     app.get('/', (req, res) => { res.redirect('index.html') })
 
-    // Serve app content
-    app.use(express.static(path.join(__dirname, '../app')))
+    // Use gzip to compress served files
+    app.use(compression())
+
+    // Serve app content and cache it for a week
+    app.use(express.static(path.join(__dirname, '../app'), {maxage: 7 * 86400000}))
 
     // Proxy requests to /api/* to API backend
     app.use('/api/*', proxy(config.apiEndpoint, {

--- a/server/package.json
+++ b/server/package.json
@@ -25,10 +25,13 @@
       "afterEach",
       "it"
     ],
-    "ignore": ["/app/"]
+    "ignore": [
+      "/app/"
+    ]
   },
   "dependencies": {
     "body-parser": "^1.15.2",
+    "compression": "^1.6.2",
     "express": "^4.14.0",
     "express-http-proxy": "^0.10.0"
   }


### PR DESCRIPTION
These little changes tell our node server to cache and gzip static assets. This should reduce the network traffic for the initial page load by roughly two thirds :tada:.
