### PR TITLE
Show directions to PokePOIs

### DIFF
--- a/ionic2/app/components/poke-poi-card/poke-poi-card.component.html
+++ b/ionic2/app/components/poke-poi-card/poke-poi-card.component.html
@@ -22,7 +22,7 @@
 
 
         <ion-row class="action-button-bar">
-          <button clear (click)="launchDirections()">
+          <button clear (click)="showDirections()">
             <ion-icon name="navigate"></ion-icon>
             Directions
           </button>

--- a/ionic2/app/components/poke-poi-card/poke-poi-card.component.ts
+++ b/ionic2/app/components/poke-poi-card/poke-poi-card.component.ts
@@ -1,6 +1,6 @@
 import { Component, ViewChild, OnInit, ElementRef, ChangeDetectorRef,
   animate, trigger, state, style, transition } from '@angular/core';
-import { NavController } from 'ionic-angular';
+import { NavController, Events } from 'ionic-angular';
 import { Subscription } from 'rxjs';
 
 import { ApiService } from '../../services/api.service';
@@ -37,7 +37,8 @@ export class PokePOICardComponent implements OnInit {
 
   constructor(private navCtrl: NavController,
               private apiService: ApiService,
-              private changeDetectorRef: ChangeDetectorRef) {}
+              private changeDetectorRef: ChangeDetectorRef,
+              private events: Events) {}
 
   ngOnInit() {
     let hammer = new Hammer(this.slideCard.nativeElement);
@@ -79,8 +80,8 @@ export class PokePOICardComponent implements OnInit {
     }
   }
 
-  launchDirections() {
-    // TODO
+  showDirections() {
+    this.events.publish('map:directions', this.pokePOI.getLocation());
   }
 
   launchPokeDex() {

--- a/ionic2/package.json
+++ b/ionic2/package.json
@@ -16,7 +16,7 @@
     "ionic-angular": "2.0.0-beta.11",
     "ionic-native": "1.3.10",
     "ionicons": "3.0.0",
-    "pokemap-1": "^0.1.1",
+    "pokemap-1": "^0.1.4",
     "pokemap-2": "github:johartl/PokeMap-2#develop",
     "reflect-metadata": "0.1.8",
     "rxjs": "5.0.0-beta.6",


### PR DESCRIPTION
This links the "Directions" button in the PokePOI card (for sightings) to the actual PokeMap call to display the routes.
WIP because this is still waiting for https://github.com/PokemonGoers/PokeMap-1/issues/34 to be merged and hasn't actually be tested yet.
