### PR TITLE
Add postinstall hock, make all dependencies devDependencies

### DIFF
--- a/ionic2/package.json
+++ b/ionic2/package.json
@@ -1,9 +1,12 @@
 {
+  "name": "catchemall",
+  "description": "CatchEmAll: An Ionic project",
   "scripts": {
     "start": "ionic serve",
-    "test": "karma start karma.conf.js"
+    "test": "karma start karma.conf.js",
+    "postinstall": "typings install"
   },
-  "dependencies": {
+  "devDependencies": {
     "@angular/common": "2.0.0-rc.4",
     "@angular/compiler": "2.0.0-rc.4",
     "@angular/core": "2.0.0-rc.4",
@@ -20,9 +23,7 @@
     "pokemap-2": "github:johartl/PokeMap-2#develop",
     "reflect-metadata": "0.1.8",
     "rxjs": "5.0.0-beta.6",
-    "zone.js": "0.6.12"
-  },
-  "devDependencies": {
+    "zone.js": "0.6.12",
     "awesome-typescript-loader": "^1.1",
     "babel-core": "^6.14.0",
     "babel-loader": "^6.2.5",
@@ -55,8 +56,6 @@
     "url-loader": "^0.5.7",
     "webpack": "^1.13.2"
   },
-  "name": "catchemall",
-  "description": "CatchEmAll: An Ionic project",
   "cordovaPlugins": [
     "cordova-plugin-device",
     "cordova-plugin-console",


### PR DESCRIPTION
- Makes all `dependencies` `devDependencies`. The former separation between `dependencies` and `devDependencies` was very murky as you need them all to make it work. I decided to make them all `devDependencies` because our final app has everything it needs built in. So, even though it will never get published to npm, it arguably has no `dependencies` of its own, just dependencies that are needed during development.
- Call `typings` (TypeScript package manager) automatically after installation. That way nobody forgets to install the type definitions. Makes things a little easier.
- Move `name` and `description` to the top
