### PR TITLE
Fix Tauros layout bug

### DIFF
--- a/ionic2/app/pages/poke-detail/poke-detail.page.scss
+++ b/ionic2/app/pages/poke-detail/poke-detail.page.scss
@@ -10,6 +10,7 @@ ion-content {
     justify-content: center;
 
     > #header-content {
+      width: 100%;
       max-width: 700px;
 
       display: flex;


### PR DESCRIPTION
Fixes a layout bug on the PokeDex detail page. It's now the way it was always intended to be.

Bug: Tauros' header was displayed in two rows even if the screen was big enough for one row.
