### PR TITLE
Include query parameters when proxying requests

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -1,6 +1,6 @@
 module.exports = {
   listenAddress: process.env.LISTEN_ADDRESS || '127.0.0.1',
   listenPort: process.env.LISTEN_PORT || '8080',
-  apiEndpoint: process.env.API_ENDPOINT || 'pokedata.c4e3f8c7.svc.dockerapp.io:65014',
-  websocketEndpoint: process.env.WEBSOCKET_ENDPOINT || 'pokedata.c4e3f8c7.svc.dockerapp.io:65024'
+  apiEndpoint: process.env.API_ENDPOINT || 'http://pokedata.c4e3f8c7.svc.dockerapp.io:65014',
+  websocketEndpoint: process.env.WEBSOCKET_ENDPOINT || 'http://pokedata.c4e3f8c7.svc.dockerapp.io:65024'
 }

--- a/server/pokemon-server.js
+++ b/server/pokemon-server.js
@@ -4,13 +4,12 @@ const path = require('path')
 const http = require('http')
 const proxy = require('express-http-proxy')
 const compression = require('compression')
-const url = require('url')
 
 class PokemonServer {
   constructor (config) {
     // Express
     const app = express()
-    app.use(bodyParser.json())
+
     app.get('/', (req, res) => { res.redirect('index.html') })
 
     // Use gzip to compress served files
@@ -19,14 +18,14 @@ class PokemonServer {
     // Serve app content and cache it for a week
     app.use(express.static(path.join(__dirname, 'app'), {maxage: 7 * 86400000}))
 
-    // Proxy requests to /api/* to API backend
-    app.use('/api/*', proxy(config.apiEndpoint, {
-      forwardPath: (req, res) => url.parse(req.baseUrl).path
+    // Proxy requests to /api to API backend
+    app.use('/api', proxy(config.apiEndpoint, {
+      forwardPath: (req, res) => req.originalUrl
     }))
 
     // Proxy websocket requests to API backend
-    app.use('/socket.io/*', proxy(config.websocketEndpoint, {
-      forwardPath: (req, res) => url.parse(req.baseUrl).path
+    app.use('/socket.io', proxy(config.websocketEndpoint, {
+      forwardPath: (req, res) => req.originalUrl
     }))
 
     this._app = app

--- a/server/pokemon-server.js
+++ b/server/pokemon-server.js
@@ -9,7 +9,7 @@ class PokemonServer {
   constructor (config) {
     // Express
     const app = express()
-
+    app.use(bodyParser.json())
     app.get('/', (req, res) => { res.redirect('index.html') })
 
     // Use gzip to compress served files


### PR DESCRIPTION
Currently when proxying requests we don't include the query search params. 
Thus, a request to `/socket.io/?EIO=3&transport=polling&t=LVo2aSr` will be simply redirected to `/socket.io` which causes some failed requests.
