### PR TITLE
Remove body parser middleware

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -30,7 +30,6 @@
     ]
   },
   "dependencies": {
-    "body-parser": "^1.15.2",
     "compression": "^1.6.2",
     "express": "^4.14.0",
     "express-http-proxy": "^0.10.0"

--- a/server/pokemon-server.js
+++ b/server/pokemon-server.js
@@ -1,5 +1,4 @@
 const express = require('express')
-const bodyParser = require('body-parser')
 const path = require('path')
 const http = require('http')
 const proxy = require('express-http-proxy')
@@ -10,7 +9,7 @@ class PokemonServer {
   constructor (config) {
     // Express
     const app = express()
-    app.use(bodyParser.json())
+
     app.get('/', (req, res) => { res.redirect('index.html') })
 
     // Use gzip to compress served files


### PR DESCRIPTION
In our node server we are parsing JSON body which we don't actually need to. We only serve static content or redirect all other requests to the PokeData backend.
