### PR TITLE
Websocket proxy

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "compression": "^1.6.2",
     "express": "^4.14.0",
-    "express-http-proxy": "^0.10.0",
+    "http-proxy-middleware": "^0.17.2",
     "morgan": "^1.7.0"
   }
 }

--- a/server/pokemon-server.js
+++ b/server/pokemon-server.js
@@ -1,7 +1,7 @@
 const express = require('express')
 const path = require('path')
 const http = require('http')
-const proxy = require('express-http-proxy')
+const proxy = require('http-proxy-middleware')
 const compression = require('compression')
 const logger = require('morgan')
 
@@ -21,14 +21,10 @@ class PokemonServer {
     app.use(express.static(path.join(__dirname, 'app'), {maxage: 7 * 86400000}))
 
     // Proxy requests to /api to API backend
-    app.use('/api', proxy(config.apiEndpoint, {
-      forwardPath: (req, res) => req.originalUrl
-    }))
+    app.use('/api', proxy(config.apiEndpoint))
 
     // Proxy websocket requests to API backend
-    app.use('/socket.io', proxy(config.websocketEndpoint, {
-      forwardPath: (req, res) => req.originalUrl
-    }))
+    app.use('/socket.io', proxy(config.websocketEndpoint, {ws: true}))
 
     this._app = app
 


### PR DESCRIPTION
Sorry, yet another websocket proxy fix :/ The old proxy middleware we were using did not properly support websockets. 
I tested this change with PokeMap-2 and the websocket connection was established successfully. For PokeMap-1 the websocket connection is still not working due to https://github.com/PokemonGoers/PokeMap-1/issues/42.
