### PR TITLE
Proxy server change origin + Log level and formatting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,12 @@ ENV LISTEN_PORT=8080
 ENV API_ENDPOINT=http://pokedata.c4e3f8c7.svc.dockerapp.io:65014
 ENV WEBSOCKET_ENDPOINT=http://pokedata.c4e3f8c7.svc.dockerapp.io:65024
 
+# https://github.com/expressjs/morgan#predefined-formats
+ENV REQUEST_LOG_FORMAT=short
+
+# debug|info|warn|error|silent
+ENV PROXY_LOG_LEVEL=info
+
 WORKDIR /usr/src/pokemon-app
 
 Add ionic2 ionic2

--- a/server/config.js
+++ b/server/config.js
@@ -2,5 +2,7 @@ module.exports = {
   listenAddress: process.env.LISTEN_ADDRESS || '127.0.0.1',
   listenPort: process.env.LISTEN_PORT || '8080',
   apiEndpoint: process.env.API_ENDPOINT || 'http://pokedata.c4e3f8c7.svc.dockerapp.io:65014',
-  websocketEndpoint: process.env.WEBSOCKET_ENDPOINT || 'http://pokedata.c4e3f8c7.svc.dockerapp.io:65024'
+  websocketEndpoint: process.env.WEBSOCKET_ENDPOINT || 'http://pokedata.c4e3f8c7.svc.dockerapp.io:65024',
+  requestLogFormat: process.env.REQUEST_LOG_FORMAT || 'short', // https://github.com/expressjs/morgan#predefined-formats
+  proxyLogLevel: process.env.PROXY_LOG_LEVEL || 'info' // debug|info|warn|error|silent
 }

--- a/server/pokemon-server.js
+++ b/server/pokemon-server.js
@@ -10,7 +10,7 @@ class PokemonServer {
     // Express
     const app = express()
 
-    app.use(logger('short'))
+    app.use(logger(config.requestLogFormat))
 
     app.get('/', (req, res) => { res.redirect('index.html') })
 
@@ -21,10 +21,10 @@ class PokemonServer {
     app.use(express.static(path.join(__dirname, 'app'), {maxage: 7 * 86400000}))
 
     // Proxy requests to /api to API backend
-    app.use('/api', proxy(config.apiEndpoint))
+    app.use('/api', proxy(config.apiEndpoint, {changeOrigin: true, logLevel: config.proxyLogLevel}))
 
     // Proxy websocket requests to API backend
-    app.use('/socket.io', proxy(config.websocketEndpoint, {ws: true}))
+    app.use('/socket.io', proxy(config.websocketEndpoint, {ws: true, changeOrigin: true, logLevel: config.proxyLogLevel}))
 
     this._app = app
 


### PR DESCRIPTION
This PR adds two things:
(Sorry for two separate concerns in one PR but these changes are really tiny and I want them to be merged as soon as possible)
- Change origin for proxy requests. This fixes an error we currently see `Error occured while trying to proxy to: localhost:8080/api/pokemon`.
- Environment variables to specify the log level for the proxy server and the log format for the request logger.
  `REQUEST_LOG_FORMAT=short`
  `PROXY_LOG_LEVEL=info`

I would like to merge this today so we can eliminate the change origin issue as source of error for #139.
