### PR TITLE
Improve filter performance

### DIFF
--- a/ionic2/src/components/filter-pokemon-tab/filter-pokemon-tab.component.html
+++ b/ionic2/src/components/filter-pokemon-tab/filter-pokemon-tab.component.html
@@ -31,7 +31,7 @@
       </ion-col>
       <ion-col end style="display: flex; align-items: center; flex-basis: 40px;
           flex-grow: 0; flex-direction: column;">
-          <img [src]="pokemonContainer.pokemon.gifIcon">
+          <img [src]="pokemonContainer.pokemon.svgIcon">
       </ion-col>
     </ion-row>
   </div>

--- a/ionic2/src/components/filter/filter.component.ts
+++ b/ionic2/src/components/filter/filter.component.ts
@@ -6,13 +6,9 @@ import { ViewController } from 'ionic-angular';
   templateUrl:  './filter.component.html'
 })
 export class FilterComponent {
-  currentTab: string;
+  currentTab: string = 'time';
 
   constructor(private viewController: ViewController) { }
-
-  ionViewWillEnter() {
-    this.currentTab = 'time';
-  }
 
   close(): void {
     this.viewController.dismiss();

--- a/ionic2/src/index.html
+++ b/ionic2/src/index.html
@@ -15,14 +15,13 @@
     <script src="cordova.js"></script>
 
 
-    <!-- un-comment this code to enable service worker
     <script>
       if ('serviceWorker' in navigator) {
         navigator.serviceWorker.register('service-worker.js')
           .then(() => console.log('service worker installed'))
           .catch(err => console.log('Error', err));
       }
-    </script>-->
+    </script>
 
     <link href="build/main.css" rel="stylesheet">
 


### PR DESCRIPTION
Set the default tab earlier, use the svgIcons which will improve performance on mobile, 151 gifs is bad.
I also enabled the Service Worker to reduce the pressure on the network since the ServiceWorker will try to cache all these requests.
