### PR TITLE
Copy to server hook + Use npm scripts to build app

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,8 @@ script:
   # - npm test
 
   # Build app for browser and Android platform
-  - node_modules/.bin/ionic build browser
-  - node_modules/.bin/ionic build android
+  - npm run build:browser
+  - npm run build:android
 
 after_success:
   # Upload apk to HockeyApp

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,11 +29,7 @@ RUN cd ionic2 && npm install -q && npm prune
 RUN cd ionic2 && npm update -q pokemap-1 pokemap-2
 
 # Build web app
-RUN cd ionic2 && ionic prepare
-RUN cd ionic2 && ionic build browser
-
-# Copy bundled web app to server directory
-RUN rm -rf server/app && cp -r ionic2/platforms/browser/www server/app
+RUN cd ionic2 && npm run build:browser
 
 # Clean workspace
 RUN rm -rf ionic2

--- a/README.md
+++ b/README.md
@@ -38,15 +38,9 @@ Run `ionic serve` in the `./ionic2` folder to start the server at `http://localh
 
 ### Without Docker
 
-1. In `./ionic2` run
+1. In `./ionic2` run `npm run build:browser`
 
-    `ionic prepare`
-
-    `ionic build browser`
-
-2. In `./server` run
-
-    `npm start`
+2. In `./server` run `npm start`
 
 3. Go to `http://localhost:8080`
 
@@ -54,11 +48,7 @@ Run `ionic serve` in the `./ionic2` folder to start the server at `http://localh
 
 First make sure that the Android SDK is installed and that `ANDROID_HOME` is set.
 
-1. In `./ionic2` run
-
-    `ionic prepare`
-
-    `ionic build android`
+1. In `./ionic2` run `npm run build:android`
 
 2. The final app apk can be found at `./ionic2/platforms/android/build/outputs/apk/android-debug.apk`.
 

--- a/ionic2/hooks/after_build/020_copy_to_server.js
+++ b/ionic2/hooks/after_build/020_copy_to_server.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+const path = require('path');
+const fs = require('fs-extra');
+const del = require('del');
+
+const scriptName = __filename.split(/[\\/]/).pop();
+const rootDir = process.argv[2];
+
+let platforms = (process.env.CORDOVA_PLATFORMS ? process.env.CORDOVA_PLATFORMS.split(',') : []);
+if (platforms.indexOf('browser') === -1) {
+  // We are only interested in browser builds
+  process.exit(0);
+}
+
+if (!rootDir) {
+  console.error(scriptName,  'No root dir given');
+  process.exit(1);
+}
+
+let buildDir = path.resolve(rootDir, 'platforms', 'browser', 'www');
+let serverDir = path.resolve(rootDir, '..', 'server');
+let serverAppDir = path.resolve(serverDir, 'app');
+
+if (!fs.existsSync(buildDir)) {
+  console.error(scriptName, `Build dir not found at '${buildDir}'`);
+  return;
+}
+
+if (!fs.existsSync(serverDir)) {
+  console.error(scriptName, `Server dir not found at '${serverDir}'`);
+  return;
+}
+
+if (fs.existsSync(serverAppDir)) {
+  console.log(scriptName, `Cleaning server dir '${serverAppDir}'`);
+  del.sync(serverAppDir, {force: true});
+}
+
+console.log(scriptName, `Copying bundled app from '${buildDir}' to '${serverAppDir}'`);
+fs.copySync(buildDir, serverAppDir);

--- a/ionic2/package.json
+++ b/ionic2/package.json
@@ -3,6 +3,8 @@
   "description": "CatchEmAll: An Ionic project",
   "scripts": {
     "build": "ionic-app-scripts build",
+    "build:browser": "ionic prepare && ionic build browser",
+    "build:android": "ionic prepare && ionic build android",
     "watch": "ionic-app-scripts watch",
     "serve:before": "watch",
     "emulate:before": "build",
@@ -25,6 +27,8 @@
     "@types/hammerjs": "^2.0.33",
     "@types/socket.io-client": "^1.4.27",
     "cordova": "^6.3.1",
+    "del": "^2.2.2",
+    "fs-extra": "^1.0.0",
     "hammerjs": "^2.0.8",
     "ionic": "^2.1.1",
     "ionic-angular": "2.0.0-rc.1",


### PR DESCRIPTION
Rather than copying the bundled app sources to `/server/app` manually I added an ionic/cordova hook to do this. I also added two npm run tasks `build:android` and `build:browser` which are further used in #164.